### PR TITLE
Feat/auction mypage/myinfo/#9 - 내정보 구역 컴포넌트 분리 및 라우팅 추가

### DIFF
--- a/src/components/mypage/myInfo/MyInfo.tsx
+++ b/src/components/mypage/myInfo/MyInfo.tsx
@@ -1,0 +1,65 @@
+import {
+  Avatar,
+  Box,
+  Button,
+  Flex,
+  Input,
+  InputGroup,
+  InputRightElement,
+  List,
+  ListItem,
+  Spacer,
+  UnorderedList,
+} from '@chakra-ui/react';
+import Calendar from '../calendar/Calendar';
+
+export default function MyInfo() {
+  return (
+    <Box flex={1} bgColor={'lightgray'} className="p-12 flex justify-center">
+      <Flex gap={10}>
+        <Avatar width={'120px'} height={'120px'} />
+        <Flex direction={'column'} bgColor={'skyblue'} gap={4}>
+          <Flex gap={16}>
+            <Flex direction={'column'} gap={2}>
+              <Flex>
+                <div>아이디</div>
+                <Spacer />
+                <div>수정</div>
+              </Flex>
+              <InputGroup>
+                <Input width={'300px'} />
+              </InputGroup>
+            </Flex>
+            <Flex direction={'column'} gap={2}>
+              <Flex>
+                <div>이메일</div>
+                <Spacer />
+                <div>수정</div>
+              </Flex>
+              <InputGroup>
+                <Input width={'350px'} />
+                <InputRightElement width={'5rem'}>
+                  <Button fontSize={'small'}>인증번호 받기</Button>
+                </InputRightElement>
+              </InputGroup>
+            </Flex>
+          </Flex>
+          <UnorderedList className="text-sm mb-6">
+            <ListItem>
+              닉네임 또는 이메일은 최초 설정 또는 변경 후 30일이 지나야 바꿀 수 있습니다.
+            </ListItem>
+            <ListItem>소셜로그인 계정은 정보를 수정할 수 없습니다.</ListItem>
+            <ListItem>이메일과 동일한 아이디는 사용이 불가능합니다.</ListItem>
+          </UnorderedList>
+          <Calendar />
+          <List spacing={1}>
+            <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
+            <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
+            <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
+            <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
+          </List>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/pages/AuctionMyPage.tsx
+++ b/src/pages/AuctionMyPage.tsx
@@ -1,22 +1,10 @@
-import {
-  Avatar,
-  Box,
-  Button,
-  Flex,
-  Input,
-  InputGroup,
-  InputRightElement,
-  List,
-  ListItem,
-  Spacer,
-  UnorderedList,
-} from '@chakra-ui/react';
-import Calendar from '../components/mypage/calendar/Calendar';
+import { Flex, List, ListItem, Spacer } from '@chakra-ui/react';
 import { FaGear, FaUser } from 'react-icons/fa6';
 import { FaShoppingCart } from 'react-icons/fa';
 import { RiDiscountPercentFill } from 'react-icons/ri';
 import { SiLightning } from 'react-icons/si';
 import { IoAlertCircle } from 'react-icons/io5';
+import MyInfo from '../components/mypage/myInfo/MyInfo';
 
 export default function AuctionMyPage() {
   return (
@@ -50,52 +38,7 @@ export default function AuctionMyPage() {
           </ListItem>
         </List>
       </Flex>
-      <Box flex={1} bgColor={'lightgray'} className="p-12 flex justify-center">
-        <Flex gap={10}>
-          <Avatar width={'120px'} height={'120px'} />
-          <Flex direction={'column'} bgColor={'skyblue'} gap={4}>
-            <Flex gap={16}>
-              <Flex direction={'column'} gap={2}>
-                <Flex>
-                  <div>아이디</div>
-                  <Spacer />
-                  <div>수정</div>
-                </Flex>
-                <InputGroup>
-                  <Input width={'300px'} />
-                </InputGroup>
-              </Flex>
-              <Flex direction={'column'} gap={2}>
-                <Flex>
-                  <div>이메일</div>
-                  <Spacer />
-                  <div>수정</div>
-                </Flex>
-                <InputGroup>
-                  <Input width={'350px'} />
-                  <InputRightElement width={'5rem'}>
-                    <Button fontSize={'small'}>인증번호 받기</Button>
-                  </InputRightElement>
-                </InputGroup>
-              </Flex>
-            </Flex>
-            <UnorderedList className="text-sm mb-6">
-              <ListItem>
-                닉네임 또는 이메일은 최초 설정 또는 변경 후 30일이 지나야 바꿀 수 있습니다.
-              </ListItem>
-              <ListItem>소셜로그인 계정은 정보를 수정할 수 없습니다.</ListItem>
-              <ListItem>이메일과 동일한 아이디는 사용이 불가능합니다.</ListItem>
-            </UnorderedList>
-            <Calendar />
-            <List spacing={1}>
-              <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
-              <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
-              <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
-              <ListItem className="p-3 border border-black">메시 국대 유니폼 입찰</ListItem>
-            </List>
-          </Flex>
-        </Flex>
-      </Box>
+      <MyInfo />
     </Flex>
   );
 }

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -3,6 +3,7 @@ import Layout from '../components/layout/Layout';
 import Home from '../pages/Home';
 import AuctionDetail from '../pages/AuctionDetail';
 import AuctionMyPage from '../pages/AuctionMyPage';
+import MyInfo from '../components/mypage/myInfo/MyInfo';
 
 export const router = createBrowserRouter([
   {
@@ -20,6 +21,12 @@ export const router = createBrowserRouter([
       {
         path: '/mypage',
         element: <AuctionMyPage />,
+        children: [
+          {
+            path: '/mypage/myinfo',
+            element: <MyInfo />,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## 📍 AS-IS
- 마이페이지 내에서 내 정보 구역을 구현하였으나, 전체 마이페이지 컴포넌트 내에 포함되어 있어 코드가 복잡하고 유지보수가 어려웠음.
- 내 정보 구역을 별도로 분리할 필요가 있음.

## 📍 TO-BE
- 내정보 구역을 `MyInfo` 컴포넌트로 분리하여 독립적으로 관리 가능하게 변경.
- `/mypage/myinfo` 경로로 접근 시 `MyInfo` 컴포넌트를 로드하도록 라우터 설정 추가.
- 마이페이지 구조가 더 명확해지고, 코드의 유지보수성과 가독성이 향상됨.